### PR TITLE
Support host discovery on Mac Os

### DIFF
--- a/mccli/ssh_wrapper.py
+++ b/mccli/ssh_wrapper.py
@@ -1,4 +1,3 @@
-from cmath import log
 import struct
 import fcntl
 import termios
@@ -7,8 +6,6 @@ import sys
 import re
 import pexpect
 import os
-import ipaddress
-import socket
 from functools import partial
 from click import echo
 from random import randint

--- a/mccli/ssh_wrapper.py
+++ b/mccli/ssh_wrapper.py
@@ -1,3 +1,4 @@
+from cmath import log
 import struct
 import fcntl
 import termios
@@ -6,6 +7,8 @@ import sys
 import re
 import pexpect
 import os
+import ipaddress
+import socket
 from functools import partial
 from click import echo
 from random import randint
@@ -14,13 +17,7 @@ from .logging import logger
 
 
 PASSWORD_REGEX = r"(?:[^\n]*)(?:Access Token:)$"
-SSH_HOSTNAME_REGEX = r"debug1: Connecting to (?P<host>\S+) \[\S+\] port \d+."
-SSH_HOSTNAME_PATTERN = re.compile(SSH_HOSTNAME_REGEX)
-BIND_ADDRESS = "SOMETHING_OBVIOUSLY_WRONG_1234567890"
-ERROR_MSG_1 = "Name or service not known"
-ERROR_MSG_2 = "No address associated with hostname"
-SSH_ERROR_BIND_ADDRESS = rf"(?P<errorprefix>getaddrinfo: {BIND_ADDRESS}:) (?P<errormsg>[^\r\n]+)"
-
+SSH_HOSTNAME_PATTERN = re.compile(r"^hostname\s+(?P<hostname>\S+)\s+$", flags=re.MULTILINE)
 
 def ssh_wrap(ssh_args, username, token, str_get_token=None, dry_run=False):
     """Runs the ssh command given by list of ssh_args, using given username
@@ -84,35 +81,30 @@ def scp_wrap(scp_args, username=None, tokens=None, str_get_tokens=None,
 
 
 def get_hostname(ssh_args):
-    """(HACKY) Try to get the ssh host from `ssh_args`
-    by executing the ssh command with invalid `-b` option
+    """Try to get the ssh host from `ssh_args`
+    by executing the ssh command with `-G` option
     and parsing the output for the actual HOSTNAME.
     """
-    # add strange option to make ssh fail without even sstarting pre-auth
-    add_opts = ['ssh', '-v', '-b', BIND_ADDRESS]
-    new_args = ssh_args.copy()
-    # remove possible duplicate -b options
-    for i in range(new_args.count('-b')):
-        index = new_args.index('-b')
-        del new_args[index:index+2]
-    new_args = add_opts + new_args
-    command = " ".join(new_args)
+    # add -G option to make ssh print its configuration
+    ssh_args = ssh_args.copy()
+    if "-G" not in ssh_args:
+        ssh_args.append("-G")
+
+    command = f"ssh {' '.join(ssh_args)}" 
+
     try:
-        logger.debug(f"Running this command is expected to fail: {command}")
-        child_process = pexpect.spawn(command)
-        child_process.expect(SSH_ERROR_BIND_ADDRESS)
-        errorprefix = child_process.match.group('errorprefix').decode('utf-8')
-        errormsg = child_process.match.group('errormsg').decode('utf-8')
-        logger.debug(f"Command failed with error message: '{errorprefix} {errormsg}'")
-        result = SSH_HOSTNAME_PATTERN.search(
-            child_process.before.decode("utf-8"))
-        if result:
-            hostname = result.group("host")
-            logger.debug(f"Found hostname by parsing command error logs: {hostname}")
-            return hostname
+        logger.debug(f"Running this command to get ssh configuration: {command}")
+        output = pexpect.run(command).decode("utf-8")
+        pattern_match = SSH_HOSTNAME_PATTERN.search(output)
+        if not pattern_match:
+            logger.error(f"Could not find hostname from ssh command {command}")
+            return None
+        hostname = pattern_match.group("hostname")
+        logger.debug(f"Found hostname by parsing command output: {hostname}")
+        return hostname
     except pexpect.ExceptionPexpect as e:
         logger.debug(e)
-        logger.info("Error trying to get real hostname from ssh command")
+        logger.error(f"Error trying to get real hostname from ssh command {command}")
     return None
 
 

--- a/mccli/ssh_wrapper.py
+++ b/mccli/ssh_wrapper.py
@@ -86,9 +86,12 @@ def get_hostname(ssh_args):
     and parsing the output for the actual HOSTNAME.
     """
     # add -G option to make ssh print its configuration
+    # option added to the beginning of the list to avoid clashes with
+    #   parameters from command to be executed remotely, e.g.:
+    #   `ssh host ls -l`
     ssh_args = ssh_args.copy()
     if "-G" not in ssh_args:
-        ssh_args.append("-G")
+        ssh_args.insert(0, "-G")
 
     command = f"ssh {' '.join(ssh_args)}" 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = mccli
 summary = SSH client wrapper for SSH with access token
-description-file = README.md
+description-file = README.rst
 description-content-type = text/markdown; charset=UTF-8
 
 author = Diana Gudu
@@ -10,7 +10,7 @@ author-email = gudu@kit.edu
 home-page = https://github.com/dianagudu/mccli
 project_urls =
     Bug Tracker = https://github.com/dianagudu/mccli/issues
-    Documentation = https://github.com/dianagudu/mccli/blob/main/README.md
+    Documentation = https://github.com/dianagudu/mccli/blob/main/README.rst
 
 license = MIT 
 license_file = LICENSE


### PR DESCRIPTION
Unfortunately, the SSH flavours of Linux and Mac OS do not behave identically. The "hacky"  `get_hostname` function using a ssh command with invalid `-b` option is not failing on Mac OS (Version 11.6.3). Instead the broken binding is simply ignored and the command is not terminated.

This pull request adds a potentially more sophiscated way to get the hostname from parsing the ssh arguments itself and validating it afterwards by checking for an valid IPv4, IPv6 address or DNS lookup of the hostname.