### PR TITLE
add support for one time tokens when AT too long

### DIFF
--- a/mccli/click_utils.py
+++ b/mccli/click_utils.py
@@ -152,9 +152,7 @@ def basic_options(func):
     @access_token_sources
     @motley_cue_options
     @verbosity_options
-    @optgroup.option(
-        "--dry-run", is_flag=True, callback=validate_pass_from_parent, hidden=True
-    )
+    @optgroup.option("--dry-run", is_flag=True, callback=validate_pass_from_parent, hidden=True)
     @help_options
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -198,10 +196,7 @@ def validate_verify(ctx, param, value):
     except Exception:
         # set the verify in the context meta dict to be used by subcommands
         # only if it was set through the commandline
-        if (
-            ctx.get_parameter_source(param.name)
-            is click.core.ParameterSource.COMMANDLINE
-        ):
+        if ctx.get_parameter_source(param.name) is click.core.ParameterSource.COMMANDLINE:
             ctx.meta[param.name] = value
     if not value:
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -223,11 +218,7 @@ def validate_pass_from_parent(ctx, param, value):
     # set meta value to be used by subcommands only if it was set using the cmdline
     # envvar values should only be processed at subcommand level and not passed from parent
     # this way, the cmdline values take precedence over env vars or default values
-    if (
-        value
-        and ctx.get_parameter_source(param.name)
-        is click.core.ParameterSource.COMMANDLINE
-    ):
+    if value and ctx.get_parameter_source(param.name) is click.core.ParameterSource.COMMANDLINE:
         ctx.meta[param.name] = value
     return value
 
@@ -265,18 +256,13 @@ def my_logging_simple_verbosity_option(logger=None, *names, **kwargs):
             except Exception as e:
                 # set the log_level in the context meta dict to be used by subcommands
                 # only if it was set through the commandline
-                if (
-                    ctx.get_parameter_source(param.name)
-                    is click.core.ParameterSource.COMMANDLINE
-                ):
+                if ctx.get_parameter_source(param.name) is click.core.ParameterSource.COMMANDLINE:
                     ctx.meta["log_level"] = value
 
             x = getattr(logging, value, None)
             if x is None:
                 raise click.BadParameter(
-                    "Must be CRITICAL, ERROR, WARNING, INFO or DEBUG, not {}".format(
-                        value
-                    )
+                    "Must be CRITICAL, ERROR, WARNING, INFO or DEBUG, not {}".format(value)
                 )
             logger.setLevel(x)
 
@@ -429,8 +415,7 @@ def my_version_option(
                 version = metadata.version(package_name)  # type: ignore
             except metadata.PackageNotFoundError:  # type: ignore
                 raise RuntimeError(
-                    f"{package_name!r} is not installed. Try passing"
-                    " 'package_name' instead."
+                    f"{package_name!r} is not installed. Try passing" " 'package_name' instead."
                 )
 
         if version is None:
@@ -439,8 +424,7 @@ def my_version_option(
             )
 
         click.echo(
-            t.cast(str, message)
-            % {"prog": prog_name, "package": package_name, "version": version},
+            t.cast(str, message) % {"prog": prog_name, "package": package_name, "version": version},
             color=ctx.color,
         )
         ctx.exit()

--- a/mccli/info_utils.py
+++ b/mccli/info_utils.py
@@ -48,21 +48,19 @@ def get_all_info(mc_url, token, verify=False):
     if mc_url and token:
         authz_info = get_authorisation_info(mc_url, token, verify)
         if authz_info:
-            info_string += (
-                "\n==== Authorisation on service for provided token issuer (OP) ====\n"
-            )
+            info_string += "\n==== Authorisation on service for provided token issuer (OP) ====\n"
             info_string += json.dumps(authz_info, indent=4)
             info_string += "\n"
         local_status = get_local_status(mc_url, token, verify)
         if local_status:
-            info_string += "\n==== Information about your local account on service for provided token ====\n"
+            info_string += (
+                "\n==== Information about your local account on service for provided token ====\n"
+            )
             info_string += local_status
             info_string += "\n"
     if token:
         access_token_info = get_access_token_info(token)
-        info_string += (
-            "\n==== Information stored inside the provided Access Token ====\n"
-        )
+        info_string += "\n==== Information stored inside the provided Access Token ====\n"
         if access_token_info:
             info_string += json.dumps(
                 {
@@ -90,9 +88,8 @@ def get_all_info(mc_url, token, verify=False):
                 if timeleft > 0:
                     info_string += "\nToken valid for %.1f more seconds." % timeleft
                 else:
-                    info_string += (
-                        "\nYour token is already EXPIRED for %.1f seconds!"
-                        % abs(timeleft)
+                    info_string += "\nYour token is already EXPIRED for %.1f seconds!" % abs(
+                        timeleft
                     )
                 info_string += "\n"
 

--- a/mccli/init_utils.py
+++ b/mccli/init_utils.py
@@ -114,9 +114,7 @@ def _get_access_token(oa_account=None, iss=None, mc_endpoint=None, verify=True):
 
 
 @_validate_token_length
-def init_token(
-    token, oa_account, iss, mc_endpoint=None, verify=True, validate_length=True
-):
+def init_token(token, oa_account, iss, mc_endpoint=None, verify=True, validate_length=True):
     """Retrieve an oidc token:
 
     * use token if set,
@@ -145,9 +143,7 @@ def init_token(
             logger.debug(f"Access Token: {token}")
             return token, _str_init_token(token=token)
         elif timeleft > 0:
-            logger.info(
-                f"Token valid for {timeleft} more seconds, using provided token."
-            )
+            logger.info(f"Token valid for {timeleft} more seconds, using provided token.")
             logger.debug(f"Access Token: {token}")
             return token, _str_init_token(token=token)
         else:
@@ -184,9 +180,7 @@ def init_token(
                 )
             return _get_access_token(iss=iss, mc_endpoint=mc_endpoint)
         except Exception as e:
-            logger.warning(
-                f"Failed to get Access Token from oidc-agent for issuer '{iss}': {e}."
-            )
+            logger.warning(f"Failed to get Access Token from oidc-agent for issuer '{iss}': {e}.")
             logger.warning(
                 f"Are you sure the issuer URL is correct or that you have an account configured with oidc-agent for this issuer? Create it with:\n    {oidc_gen_command(iss)}"
             )
@@ -210,9 +204,7 @@ def init_token(
                     f"If you don't have an oidc-agent account configured for this issuer, create it with:\n    {oidc_gen_command(iss)}"
                 )
         elif len(supported_ops) > 1:
-            logger.warning(
-                "Multiple issuers supported on service, I don't know which one to use:"
-            )
+            logger.warning("Multiple issuers supported on service, I don't know which one to use:")
             logger.warning("[" + "\n    ".join([""] + supported_ops) + "\n]")
     if expired:
         msg = (
@@ -336,14 +328,10 @@ def augmented_scp_command(scp_command, token, oa_account, iss, verify=False):
     for operand in scp_command.sources + [scp_command.target]:
         if operand.remote and operand.user is None:
             # this is definitely a motley_cue managed host
-            logger.debug(
-                f"Trying to get username from motley_cue service on {operand.host}."
-            )
+            logger.debug(f"Trying to get username from motley_cue service on {operand.host}.")
             mc_url = init_endpoint([operand.host], verify)
             logger.debug("mc endpoint: %s", mc_url)
-            at, str_get_at = init_token(
-                token, oa_account, iss, mc_endpoint=mc_url, verify=verify
-            )
+            at, str_get_at = init_token(token, oa_account, iss, mc_endpoint=mc_url, verify=verify)
             username = init_user(mc_url, at, verify)
             at, str_get_at = check_and_replace_long_token(at, str_get_at)
             scp_args += [operand.unsplit(username)]

--- a/mccli/init_utils.py
+++ b/mccli/init_utils.py
@@ -49,7 +49,7 @@ def oidc_gen_command(iss):
 
 def check_and_replace_long_token(token, str_init_token):
     """If token too long, create a new OTP to be used as ssh password, by hashing given token."""
-    if len(token) <= 1024:
+    if len(token) < 1024:
         return token, str_init_token
     otp = hashlib.sha512(bytearray(token, "ascii")).hexdigest()
     logger.debug(f"Created OTP [{otp}] to be used as SSH password.")
@@ -65,7 +65,7 @@ def _validate_token_length(func):
 
     def wrapper(*args, **kwargs):
         at, str_get_at = func(*args, **kwargs)
-        if kwargs.get("validate_length", True) and len(at) > 1024:
+        if kwargs.get("validate_length", True) and len(at) >= 1024:
             mc_endpoint = kwargs.get("mc_endpoint", None)
             verify = kwargs.get("verify", True)
             response = generate_otp(mc_endpoint=mc_endpoint, token=at, verify=verify)
@@ -76,7 +76,7 @@ def _validate_token_length(func):
                 use_otp = supported and successful
             if not use_otp:
                 raise Exception(
-                    f"Sorry, your token is too long ({len(at)} > 1024) and cannot be used for SSH "
+                    f"Sorry, your token is too long ({len(at)} >= 1024) and cannot be used for SSH "
                     "authentication. Please ask your OP admin if they can release shorter tokens, "
                     "or the service admin if they can support one-time passwords."
                 )

--- a/mccli/mccli.py
+++ b/mccli/mccli.py
@@ -122,9 +122,7 @@ def ssh(mc_endpoint, verify, no_cache, token, oa_account, iss, dry_run, ssh_comm
             mc_url = valid_mc_url(mc_endpoint, verify)
         else:
             mc_url = init_endpoint(ssh_command, verify)
-        at, str_get_at = init_token(
-            token, oa_account, iss, mc_endpoint=mc_url, verify=verify
-        )
+        at, str_get_at = init_token(token, oa_account, iss, mc_endpoint=mc_url, verify=verify)
         username = init_user(mc_url, at, verify)
         at, str_get_at = check_and_replace_long_token(at, str_get_at)
         ssh_wrap(ssh_command, username, at, str_get_token=str_get_at, dry_run=dry_run)
@@ -169,9 +167,7 @@ def scp(mc_endpoint, verify, no_cache, token, oa_account, iss, dry_run, scp_comm
             init_cache()
         if mc_endpoint:
             mc_url = valid_mc_url(mc_endpoint, verify)
-            at, str_get_at = init_token(
-                token, oa_account, iss, mc_endpoint=mc_url, verify=verify
-            )
+            at, str_get_at = init_token(token, oa_account, iss, mc_endpoint=mc_url, verify=verify)
             username = init_user(mc_url, at, verify)
             at, str_get_at = check_and_replace_long_token(at, str_get_at)
             scp_wrap(

--- a/mccli/mccli.py
+++ b/mccli/mccli.py
@@ -10,6 +10,7 @@ from .init_utils import (
     init_user,
     init_cache,
     augmented_scp_command,
+    check_and_replace_long_token,
 )
 from .scp_utils import parse_scp_args
 from .click_utils import (
@@ -64,7 +65,12 @@ def info(mc_endpoint, verify, no_cache, token, oa_account, iss, dry_run, hostnam
         logger.warning("Cannot show service-related information.")
     try:
         at, _ = init_token(
-            token, oa_account, iss, mc_url, verify, validate_length=False
+            token,
+            oa_account,
+            iss,
+            mc_endpoint=mc_url,
+            verify=verify,
+            validate_length=False,
         )
     except Exception as e:
         at = None
@@ -116,8 +122,11 @@ def ssh(mc_endpoint, verify, no_cache, token, oa_account, iss, dry_run, ssh_comm
             mc_url = valid_mc_url(mc_endpoint, verify)
         else:
             mc_url = init_endpoint(ssh_command, verify)
-        at, str_get_at = init_token(token, oa_account, iss, mc_url, verify)
+        at, str_get_at = init_token(
+            token, oa_account, iss, mc_endpoint=mc_url, verify=verify
+        )
         username = init_user(mc_url, at, verify)
+        at, str_get_at = check_and_replace_long_token(at, str_get_at)
         ssh_wrap(ssh_command, username, at, str_get_token=str_get_at, dry_run=dry_run)
     except Exception as e:
         logger.error(e)
@@ -160,8 +169,11 @@ def scp(mc_endpoint, verify, no_cache, token, oa_account, iss, dry_run, scp_comm
             init_cache()
         if mc_endpoint:
             mc_url = valid_mc_url(mc_endpoint, verify)
-            at, str_get_at = init_token(token, oa_account, iss, mc_url, verify)
+            at, str_get_at = init_token(
+                token, oa_account, iss, mc_endpoint=mc_url, verify=verify
+            )
             username = init_user(mc_url, at, verify)
+            at, str_get_at = check_and_replace_long_token(at, str_get_at)
             scp_wrap(
                 scp_command,
                 username=username,
@@ -181,8 +193,11 @@ def scp(mc_endpoint, verify, no_cache, token, oa_account, iss, dry_run, scp_comm
             elif scp_args.single_mc():
                 logger.info("Only one host with motley_cue detected. Easy.")
                 mc_url = init_endpoint([scp_args.mc_host], verify)
-                at, str_get_at = init_token(token, oa_account, iss, mc_url, verify)
+                at, str_get_at = init_token(
+                    token, oa_account, iss, mc_endpoint=mc_url, verify=verify
+                )
                 username = init_user(mc_url, at, verify)
+                at, str_get_at = check_and_replace_long_token(at, str_get_at)
                 scp_wrap(
                     scp_command,
                     username=username,

--- a/mccli/motley_cue_client.py
+++ b/mccli/motley_cue_client.py
@@ -38,6 +38,19 @@ def get_status(mc_endpoint, token, verify=True):
     return resp
 
 
+def generate_otp(mc_endpoint, token, verify=True):
+    endpoint = mc_endpoint + "/user/generate_otp"
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = requests.get(endpoint, headers=headers, verify=verify)
+
+    from_cache = getattr(resp, "from_cache", False)
+    if from_cache:
+        logger.debug(f"Using cached response for {endpoint}")
+
+    return resp
+
+
 def info(mc_endpoint, verify=True):
     endpoint = mc_endpoint + "/info"
 

--- a/mccli/motley_cue_client.py
+++ b/mccli/motley_cue_client.py
@@ -115,9 +115,7 @@ def get_audience(mc_endpoint, token, verify=True):
         resp = info_authorisation(mc_endpoint, token, verify=verify)
         return resp.json().get("audience", None)
     except Exception as e:
-        logger.debug(
-            "Failed to get audience from service, assuming no specific audience needed."
-        )
+        logger.debug("Failed to get audience from service, assuming no specific audience needed.")
     return None
 
 
@@ -135,11 +133,11 @@ def get_local_status(mc_endpoint, token, verify=True):
                 status_string = f"Your account on service has limited capabilities, but you might still be able to login. {infostring}"
                 status_string += f'\nLocal username: {output["message"].split()[1]}'
             elif state == "pending":
-                status_string = f"Your account creation on service is still pending approval. {infostring}"
-            elif state == "unknown":
                 status_string = (
-                    f"Your account on service is in an undefined state. {infostring}"
+                    f"Your account creation on service is still pending approval. {infostring}"
                 )
+            elif state == "unknown":
+                status_string = f"Your account on service is in an undefined state. {infostring}"
             elif state == "not_deployed":
                 status_string = f"Your account on service is not deployed, but it will be created on the first login if authorised."
             elif state == "deployed":
@@ -204,9 +202,7 @@ def local_username(mc_endpoint, token, verify=True):
                             f'Failed on deploy: [HTTP {resp.status_code}] [state={resp_dict["state"]}] {resp_dict["message"]}'
                         )
                     except Exception:
-                        logger.error(
-                            f"Failed on deploy: [HTTP {resp.status_code}] {resp.text}"
-                        )
+                        logger.error(f"Failed on deploy: [HTTP {resp.status_code}] {resp.text}")
             else:
                 raise Exception(
                     f"Weird, this should never have happened... Your account is in state: {state}. {infostring}"
@@ -218,9 +214,7 @@ def local_username(mc_endpoint, token, verify=True):
                     f'Failed on get_status: [HTTP {resp.status_code}] [state={resp_dict["state"]}] {resp_dict["message"]}'
                 )
             except Exception:
-                logger.error(
-                    f"Failed on get_status: [HTTP {resp.status_code}] {resp.text}"
-                )
+                logger.error(f"Failed on get_status: [HTTP {resp.status_code}] {resp.text}")
     except Exception as e:
         logger.error(f"Something went wrong: {e}")
     raise Exception("Failed to get ssh username")

--- a/mccli/scp_utils.py
+++ b/mccli/scp_utils.py
@@ -68,9 +68,7 @@ class ScpOperand:
             # format [user@]host[:path]
             if self.port:
                 # should not happen
-                raise Exception(
-                    "Port cannot be specified in this format [user@]host[:path]"
-                )
+                raise Exception("Port cannot be specified in this format [user@]host[:path]")
             if not user:
                 return f"{self.host}:{self.path}"
             else:
@@ -251,13 +249,9 @@ def __valid_path(value):
             parsed_uri = urlparse(value)
         except Exception as e:
             logger.debug(e)
-            raise Exception(
-                f"SCP operand {value} in URI form (cf RFC3986) could not be parsed"
-            )
+            raise Exception(f"SCP operand {value} in URI form (cf RFC3986) could not be parsed")
         if not parsed_uri.host or parsed_uri.host == "":
-            raise Exception(
-                f"SCP operand {value} in URI form (cf RFC3986) does not contain a host"
-            )
+            raise Exception(f"SCP operand {value} in URI form (cf RFC3986) does not contain a host")
         logger.debug(f"{parsed_uri}")
         return ScpOperand(
             remote=True,
@@ -283,13 +277,9 @@ def __valid_path(value):
         user = "@".join(user_host[:-1])
         user = None if user == "" else user
         if host == "":
-            raise Exception(
-                f"SCP operand {value} in [user@]host:[path] does not contain a host"
-            )
+            raise Exception(f"SCP operand {value} in [user@]host:[path] does not contain a host")
         logger.debug(f"ParseResult: [user={user}, host={host}, path={path}]")
-        return ScpOperand(
-            remote=True, user=user, host=host, path=path, original_str=value
-        )
+        return ScpOperand(remote=True, user=user, host=host, path=path, original_str=value)
 
 
 def __colon(value):

--- a/mccli/ssh_wrapper.py
+++ b/mccli/ssh_wrapper.py
@@ -14,9 +14,7 @@ from .logging import logger
 
 
 PASSWORD_REGEX = r"(?:[^\n]*)(?:Access Token:)$"
-SSH_HOSTNAME_PATTERN = re.compile(
-    r"^hostname\s+(?P<hostname>\S+)\s+$", flags=re.MULTILINE
-)
+SSH_HOSTNAME_PATTERN = re.compile(r"^hostname\s+(?P<hostname>\S+)\s+$", flags=re.MULTILINE)
 
 
 def ssh_wrap(ssh_args, username, token, str_get_token=None, dry_run=False):

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands = pylint --exit-zero {[base]module}
 
 [testenv:black]
 deps = black
-commands = black --check --diff {[base]module}
+commands = black -l 100 --check --diff {[base]module}
 
 [testenv:pyright]
 deps =


### PR DESCRIPTION
Support for long access tokens by calling `/user/generate_otp` on motley_cue endpoint, and, if supported, using OTP (hash of access token) as SSH password.

Might need more testing (for SCP with multiple remote hosts).