### PR TITLE
v0.7.3

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -26,7 +26,6 @@ python:
       path: .
     - requirements: doc/source/requirements.txt
     - requirements: requirements.txt
-  system_packages: true
 
 formats:
   - pdf

--- a/mccli/init_utils.py
+++ b/mccli/init_utils.py
@@ -225,13 +225,17 @@ def init_token(
                 "Could not get expiration date from provided token, it might not be a JWT. Using it anyway..."
             )
             logger.debug(f"Access Token: {token}")
-            return _get_access_token(token=token, mc_endpoint=mc_endpoint)
+            return _get_access_token(
+                token=token, mc_endpoint=mc_endpoint, verify=verify
+            )
         elif timeleft > 0:
             logger.info(
                 f"Token valid for {timeleft} more seconds, using provided token."
             )
             logger.debug(f"Access Token: {token}")
-            return _get_access_token(token=token, mc_endpoint=mc_endpoint)
+            return _get_access_token(
+                token=token, mc_endpoint=mc_endpoint, verify=verify
+            )
         else:
             expired = True
             logger.warning(
@@ -243,7 +247,9 @@ def init_token(
     if oa_account is not None:
         try:
             logger.info(f"Using oidc-agent account: {oa_account}")
-            return _get_access_token(oa_account=oa_account, mc_endpoint=mc_endpoint)
+            return _get_access_token(
+                oa_account=oa_account, mc_endpoint=mc_endpoint, verify=verify
+            )
         except Exception as e:
             logger.debug(f"Failed to get token from oidc-agent account: {e}")
             logger.warning(

--- a/mccli/motley_cue_client.py
+++ b/mccli/motley_cue_client.py
@@ -249,11 +249,6 @@ def is_valid_mc_url(mc_endpoint, verify=True):
     """
     try:
         logger.info(f"Looking for motley_cue service at '{mc_endpoint}'...")
-        parse_result = urlparse(mc_endpoint)
-        fqdn_host = socket.getfqdn(parse_result.host)
-        if fqdn_host and fqdn_host != parse_result.host:
-            mc_endpoint = parse_result.copy_with(host=fqdn_host).unsplit()
-            logger.info(f"Using FQDN for host: {mc_endpoint}")
 
         # a timeout is necessary here e.g. when the firewall drops packages
         resp = requests.get(mc_endpoint, verify=verify, timeout=TIMEOUT)

--- a/mccli/ssh_wrapper.py
+++ b/mccli/ssh_wrapper.py
@@ -54,7 +54,7 @@ def ssh_wrap(
     ssh_command_str = f"ssh -l {username} {ssh_command_str}"
     if dry_run:
         __dry_run(ssh_command_str, tokens=token, str_get_tokens=str_get_token)
-    elif sys.__stdin__.isatty():
+    elif sys.__stdin__ and sys.__stdin__.isatty():
         logger.debug("is a tty")
         __process_wrap(ssh_command_str, passwords=[token])
     else:
@@ -103,7 +103,7 @@ def scp_wrap(
     else:
         raise Exception("Unsupported use case")
 
-    if sys.__stdin__.isatty():
+    if sys.__stdin__ and sys.__stdin__.isatty():
         scp_args = ["-o", "StrictHostKeyChecking=no"] + scp_args
 
     scp_command_str = f"scp {' '.join(scp_args)}"
@@ -135,7 +135,8 @@ def get_hostname(ssh_args):
 
     try:
         logger.debug(f"Running this command to get ssh configuration: {command}")
-        output = pexpect.run(command).decode("utf-8")
+        (output, _) = pexpect.run(command)
+        output = output.decode("utf-8")
         pattern_match = SSH_HOSTNAME_PATTERN.search(output)
         if not pattern_match:
             logger.error(f"Could not find hostname from ssh command {command}")


### PR DESCRIPTION
- use mc-endpoint as given by user rather than inferring fqdn
- when set by user, do insecure requests everywhere: fixed missing ones  
- fix pyright errors